### PR TITLE
Add abortable fetch helper with schema validation and tests

### DIFF
--- a/__tests__/fetch.test.ts
+++ b/__tests__/fetch.test.ts
@@ -1,0 +1,48 @@
+import { createServer } from 'http';
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { z } from 'zod';
+
+import { safeFetch } from '../src/lib/fetch';
+
+// Helper to start server on random port
+function startServer(handler: Parameters<typeof createServer>[0]): Promise<{url: string; close: () => void}> {
+  const server = createServer(handler);
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      const address = server.address();
+      const url = `http://127.0.0.1:${(address as any).port}`;
+      resolve({ url, close: () => server.close() });
+    });
+  });
+}
+
+test('safeFetch aborts when timeout is exceeded', async () => {
+  const { url, close } = await startServer((_, res) => {
+    // Never respond within timeout
+    setTimeout(() => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end('{}');
+    }, 200);
+  });
+  let aborted = false;
+  try {
+    await safeFetch(url, { timeout: 50 });
+  } catch (e: any) {
+    aborted = e.name === 'AbortError';
+  } finally {
+    close();
+  }
+  assert.ok(aborted, 'expected request to abort');
+});
+
+test('safeFetch validates response with schema', async () => {
+  const { url, close } = await startServer((_, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ value: 42 }));
+  });
+  const schema = z.object({ value: z.number() });
+  const data = await safeFetch(url, { schema });
+  assert.equal(data.value, 42);
+  close();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "genkit-cli": "^1.8.0",
         "postcss": "^8.5.4",
         "tailwindcss": "^3.4.17",
+        "tsx": "^4.7.0",
         "typescript": "^5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "analyze": "ANALYZE=true next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@firebase/auth": "^1.10.6",
@@ -81,6 +82,7 @@
     "genkit-cli": "^1.8.0",
     "postcss": "^8.5.4",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "tsx": "^4.7.0"
   }
 }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,0 +1,29 @@
+import { ZodSchema } from 'zod';
+
+export interface SafeFetchOptions<T> extends RequestInit {
+  timeout?: number;
+  schema?: ZodSchema<T>;
+}
+
+export async function safeFetch<T = unknown>(
+  url: string,
+  { timeout = 8000, schema, signal, ...init }: SafeFetchOptions<T> = {}
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, controller.signal])
+    : controller.signal;
+  try {
+    const res = await fetch(url, { ...init, signal: combinedSignal });
+    if (!res.ok) {
+      throw new Error(`Fetch failed with status ${res.status}`);
+    }
+    const data = await res.json();
+    return schema ? schema.parse(data) : (data as T);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export default safeFetch;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+// Basic reusable schemas. More can be added as API contracts grow.
+export const menuItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  price: z.number(),
+});
+
+export type MenuItem = z.infer<typeof menuItemSchema>;


### PR DESCRIPTION
## Summary
- add `safeFetch` util supporting AbortSignal timeouts and Zod validation
- expose basic `menuItemSchema` for API reuse
- cover fetch utility with Node tests

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch Inter from Google Fonts)*
- `npm run lint` *(interactive prompt, could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a7453bf3808332a35c845c5d6cd6cb